### PR TITLE
Remove extra text codecheck yml reference

### DIFF
--- a/codecheck.yml
+++ b/codecheck.yml
@@ -8,9 +8,7 @@ paper:
     - name: Germán Vargas Mesa
     - name: Amélie A. Gagnon
       ORCID: 0000-0003-4907-0774
-  reference: >
-    IIEP technical note (2021)
-    http://www.iiep.unesco.org/en/publication/geographically-weighted-regressions-prioritizing-educational-planning-policies-and
+  reference: http://www.iiep.unesco.org/en/publication/geographically-weighted-regressions-prioritizing-educational-planning-policies-and
 
 manifest:
   - file: codecheck/results/fig4.pdf


### PR DESCRIPTION
In the `codecheck.yml` there was extra text in paper reference. I removed this extra text. 
Refer to comments in another PR about this: [link](https://github.com/codecheckers/register/issues/88#issuecomment-2343273428)

@nuest could you review and merge if you're okay with the changes. I do not have permission to merge.